### PR TITLE
added missing icons for newly added fan modes: silent, turbo

### DIFF
--- a/custom_components/tornado/climate.py
+++ b/custom_components/tornado/climate.py
@@ -43,12 +43,12 @@ HVAC_MODE_MAP_REVERSE = {v: k for k, v in HVAC_MODE_MAP.items()}
 
 # Map Tornado fan modes to Home Assistant fan modes
 FAN_MODE_MAP = {
-    0: "Auto",
-    1: "Low",
-    2: "Medium",
-    3: "High",
-    4: "Turbo",
-    5: "Silent",
+    0: "auto",
+    1: "low",
+    2: "medium",
+    3: "high",
+    4: "turbo",
+    5: "silent",
 }
 
 FAN_MODE_MAP_REVERSE = {v: k for k, v in FAN_MODE_MAP.items()}

--- a/custom_components/tornado/climate.py
+++ b/custom_components/tornado/climate.py
@@ -43,12 +43,12 @@ HVAC_MODE_MAP_REVERSE = {v: k for k, v in HVAC_MODE_MAP.items()}
 
 # Map Tornado fan modes to Home Assistant fan modes
 FAN_MODE_MAP = {
-    0: "auto",
-    1: "low",
-    2: "medium",
-    3: "high",
-    4: "turbo",
-    5: "silent",
+    0: "Auto",
+    1: "Low",
+    2: "Medium",
+    3: "High",
+    4: "Turbo",
+    5: "Silent",
 }
 
 FAN_MODE_MAP_REVERSE = {v: k for k, v in FAN_MODE_MAP.items()}

--- a/custom_components/tornado/icons.json
+++ b/custom_components/tornado/icons.json
@@ -2,29 +2,11 @@
   "entity": {
     "climate": {
       "tornado": {
-        "default": "mdi:air-conditioner",
         "state_attributes": {
           "fan_mode": {
-            "default": "mdi:fan",
             "state": {
-              "Auto": "mdi:fan-auto",
-              "Low": "mdi:speedometer-slow",
-              "Medium": "mdi:speedometer-medium",
-              "High": "mdi:speedometer",
-              "Turbo": "mdi:rocket-launch",
-              "Silent": "mdi:fan-off",
-              "Off": "mdi:fan-off"
-            }
-          },
-  
-          "swing_mode": {
-            "default": "mdi:circle-medium",
-            "state": {
-              "both": "mdi:arrow-all",
-              "horizontal": "mdi:arrow-left-right",
-              "off": "mdi:arrow-oscillating-off",
-              "on": "mdi:arrow-oscillating",
-              "vertical": "mdi:arrow-up-down"
+              "turbo": "mdi:rocket-launch",
+              "silent": "mdi:fan-off"
             }
           }
         }

--- a/custom_components/tornado/icons.json
+++ b/custom_components/tornado/icons.json
@@ -1,0 +1,34 @@
+{
+  "entity": {
+    "climate": {
+      "tornado": {
+        "default": "mdi:air-conditioner",
+        "state_attributes": {
+          "fan_mode": {
+            "default": "mdi:fan",
+            "state": {
+              "Auto": "mdi:fan-auto",
+              "Low": "mdi:speedometer-slow",
+              "Medium": "mdi:speedometer-medium",
+              "High": "mdi:speedometer",
+              "Turbo": "mdi:rocket-launch",
+              "Silent": "mdi:fan-off",
+              "Off": "mdi:fan-off"
+            }
+          },
+  
+          "swing_mode": {
+            "default": "mdi:circle-medium",
+            "state": {
+              "both": "mdi:arrow-all",
+              "horizontal": "mdi:arrow-left-right",
+              "off": "mdi:arrow-oscillating-off",
+              "on": "mdi:arrow-oscillating",
+              "vertical": "mdi:arrow-up-down"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/tornado/translations/en.json
+++ b/custom_components/tornado/translations/en.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Tornado Air Conditioner",
+        "description": "Configure your Tornado Air Conditioner",
+        "data": {
+          "email": "Email",
+          "password": "Password",
+          "region": "Region"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error occurred"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
+    }
+  },
+  "entity": {
+    "climate": {
+      "tornado": {
+        "name": "Tornado AC",
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "turbo": "Turbo",
+              "silent": "Silent"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/tornado/translations/he.json
+++ b/custom_components/tornado/translations/he.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "מזגן טורנדו",
+        "description": "הגדרת מזגן טורנדו",
+        "data": {
+          "email": "אימייל",
+          "password": "סיסמה",
+          "region": "אזור"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "נכשל בהתחברות",
+      "invalid_auth": "אימות לא תקין",
+      "unknown": "אירעה שגיאה לא צפויה"
+    },
+    "abort": {
+      "already_configured": "המכשיר כבר מוגדר"
+    }
+  },
+  "entity": {
+    "climate": {
+      "tornado": {
+        "name": "מזגן טורנדו",
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "turbo": "טורבו",
+              "silent": "שקט"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/custom_components/tornado/translations/ru.json
+++ b/custom_components/tornado/translations/ru.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Кондиционер Tornado",
+        "description": "Настройка кондиционера Tornado",
+        "data": {
+          "email": "Электронная почта",
+          "password": "Пароль",
+          "region": "Регион"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Не удалось подключиться",
+      "invalid_auth": "Неверная аутентификация",
+      "unknown": "Произошла неожиданная ошибка"
+    },
+    "abort": {
+      "already_configured": "Устройство уже настроено"
+    }
+  },
+  "entity": {
+    "climate": {
+      "tornado": {
+        "name": "Кондиционер Tornado",
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "turbo": "Турбо",
+              "silent": "Тихий"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- added the icons.json to provide icons for new fan modes: silent and turbo.
- fan modes names capitalized to have consistent UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic icon support for the Tornado climate entity, displaying different icons based on fan mode.
  * Introduced English, Hebrew, and Russian translations for the Tornado Air Conditioner integration, including configuration steps, error messages, and climate entity attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
![Screenshot_20250712_213446_Home Assistant](https://github.com/user-attachments/assets/3d5f3df6-226d-44a3-a055-b3adb8db8f93)
![Screenshot_20250712_213431_Home Assistant](https://github.com/user-attachments/assets/327f3753-a208-48a7-b929-4eda13f2c1a0)
