### PR TITLE
fix: add retry mechanism for AuxCloudApiError to handle server busy errors

### DIFF
--- a/custom_components/tornado/aux_cloud/__init__.py
+++ b/custom_components/tornado/aux_cloud/__init__.py
@@ -15,7 +15,6 @@ import aiohttp
 from async_lru import alru_cache
 from tenacity import (
     retry,
-    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -87,24 +86,19 @@ class AuxCloudConnectionError(AuxCloudError):
 
 
 # Add retry decorator configuration
-def _should_retry_api_error(exception: BaseException) -> bool:
-    """Check if an AuxCloudApiError should be retried (only server busy errors)."""
-    if not isinstance(exception, AuxCloudApiError):
-        return False
-
-    # Check if the error message contains server busy error codes
-    error_str = str(exception)
-    return "-2001" in error_str or "-30101" in error_str
-
-
 def create_retry_decorator(
     max_attempts: int = 3,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Create a retry decorator with specified parameters."""
     return retry(
         retry=retry_if_exception_type(
-            (aiohttp.ClientError, TimeoutError, AuxCloudConnectionError)
-        ) | retry_if_exception(_should_retry_api_error),
+            (
+                aiohttp.ClientError,
+                TimeoutError,
+                AuxCloudConnectionError,
+                AuxCloudApiError,
+            )
+        ),
         wait=wait_exponential(multiplier=1, min=4, max=10),
         stop=stop_after_attempt(max_attempts),
         before_sleep=lambda retry_state: _LOGGER.warning(

--- a/custom_components/tornado/aux_cloud/__init__.py
+++ b/custom_components/tornado/aux_cloud/__init__.py
@@ -92,7 +92,7 @@ def create_retry_decorator(
     """Create a retry decorator with specified parameters."""
     return retry(
         retry=retry_if_exception_type(
-            (aiohttp.ClientError, TimeoutError, AuxCloudConnectionError)
+            (aiohttp.ClientError, TimeoutError, AuxCloudConnectionError, AuxCloudApiError)
         ),
         wait=wait_exponential(multiplier=1, min=4, max=10),
         stop=stop_after_attempt(max_attempts),
@@ -535,7 +535,7 @@ class AuxCloudAPI:
                     if not isinstance(params_result, Exception):
                         dev["params"] = params_result
 
-                    if not isinstance(ambient_result, Exception):
+                    if not isinstance(ambient_result, Exception) and "params" in dev:
                         dev["params"]["envtemp"] = ambient_result["envtemp"]
                     _LOGGER.debug("Processed device: %s", dev)
                     processed_devices.append(dev)

--- a/custom_components/tornado/aux_cloud/__init__.py
+++ b/custom_components/tornado/aux_cloud/__init__.py
@@ -15,6 +15,7 @@ import aiohttp
 from async_lru import alru_cache
 from tenacity import (
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -86,14 +87,24 @@ class AuxCloudConnectionError(AuxCloudError):
 
 
 # Add retry decorator configuration
+def _should_retry_api_error(exception: BaseException) -> bool:
+    """Check if an AuxCloudApiError should be retried (only server busy errors)."""
+    if not isinstance(exception, AuxCloudApiError):
+        return False
+
+    # Check if the error message contains server busy error codes
+    error_str = str(exception)
+    return "-2001" in error_str or "-30101" in error_str
+
+
 def create_retry_decorator(
     max_attempts: int = 3,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Create a retry decorator with specified parameters."""
     return retry(
         retry=retry_if_exception_type(
-            (aiohttp.ClientError, TimeoutError, AuxCloudConnectionError, AuxCloudApiError)
-        ),
+            (aiohttp.ClientError, TimeoutError, AuxCloudConnectionError)
+        ) | retry_if_exception(_should_retry_api_error),
         wait=wait_exponential(multiplier=1, min=4, max=10),
         stop=stop_after_attempt(max_attempts),
         before_sleep=lambda retry_state: _LOGGER.warning(


### PR DESCRIPTION
## Summary
- Added AuxCloudApiError to the retry decorator exception types to automatically retry server busy errors (-2001, -30101)
- Improves reliability when the AUX Cloud API returns temporary server busy responses

## Test plan
- [ ] Verify that server busy errors are now retried automatically
- [ ] Confirm existing functionality remains unchanged
- [ ] Run automated tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded retry logic to handle more API error scenarios.
  * Enhanced stability when updating device information by ensuring required data is present before assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->