### PR TITLE
fix: force fresh connections to prevent intermittent SocketTimeoutError (stale keep-alive reuse behind AWS ELB)

### DIFF
--- a/custom_components/tornado/aux_cloud/__init__.py
+++ b/custom_components/tornado/aux_cloud/__init__.py
@@ -128,8 +128,15 @@ class AuxCloudAPI:
                     ttl_dns_cache=300,  # Cache DNS results for 5 minutes
                     use_dns_cache=True,
                     family=socket.AF_INET,
-                    keepalive_timeout=120,
-                    force_close=False,
+                    # AUX sits behind an AWS ELB whose idle timeout (~60s) is
+                    # shorter than the connector's old 120s keepalive, while the
+                    # coordinator polls every 60s. A pooled socket therefore sat
+                    # idle right across the ELB's cutoff, got silently dropped,
+                    # and the next poll reused the dead socket and hung on read
+                    # until sock_read fired. Open a fresh connection per request
+                    # instead. (keepalive_timeout must not be set with
+                    # force_close=True; aiohttp raises ValueError otherwise.)
+                    force_close=True,
                 )
                 _LOGGER.info("Created new connector: %s", id(cls._shared_connector))
 


### PR DESCRIPTION
## Problem

Every ~60s polling cycle, the `DataUpdateCoordinator` fails with:

```
Error fetching AuxCloud data: RetryError[<Future ... raised SocketTimeoutError>]
  aux_cloud/__init__.py:496 in list_devices -> session.post(...)
  aiohttp.client_exceptions.SocketTimeoutError: Timeout on reading data from socket
```

The TCP handshake succeeds but the response body never arrives, so the read hangs until `sock_read` fires. In one report the coordinator failed **30/30 consecutive cycles** over a 30-minute window, with all three tenacity attempts timing out on the first `list_devices` POST.

## Root cause

The AUX host (`app-service-usa-fd7cc04c.smarthomecs.com`) resolves to an **AWS Elastic Load Balancer** (`...us-west-1.elb.amazonaws.com`), whose idle timeout (~60s) is **shorter** than the connector's `keepalive_timeout=120`, while the coordinator polls every 60s.

A pooled keep-alive socket therefore sat idle right across the ELB's cutoff, the ELB silently reaped it, and the connector — still believing it alive — handed the dead socket to the next poll. The request went out, the ELB had already forgotten the connection, no body came back, and it hung until `sock_read`. Because connections were pooled (`force_close=False`), tenacity's retries kept drawing **other** dead sockets from the pool, so every attempt in the cycle failed.

A fresh connection to the same endpoint responds in **~1.2s**, confirming the server is healthy and the fault is stale-connection reuse — not a slow server, not IPv6 (the host publishes no AAAA record and the connector already forces `AF_INET`), not connectivity.

## Fix

Set `force_close=True` on the shared `TCPConnector` so every request — and every tenacity retry — opens a fresh connection. There is no pool to go stale, which eliminates both the stale-reuse hang and the retries-reuse-dead-socket amplifier.

`keepalive_timeout` is removed because aiohttp raises `ValueError` if it is set alongside `force_close=True`.

Timeouts are intentionally **left unchanged** (`total=30, sock_connect=10, sock_read=10`): the endpoint answers healthy requests in ~1s, so `sock_read` was never the cause, and keeping it at 10 holds the worst-case 3-attempt retry chain (~42s) under the 60s poll interval.

## Cost / trade-off

One TLS handshake per request (~0.86s observed), running concurrently within each poll burst — negligible for a `cloud_polling` integration on a 60s interval.

## Graceful degradation (already correct, unchanged)

`_async_update_data` raises `UpdateFailed` on any error, so entities go `unavailable` and auto-recover on the next successful poll.

## Testing notes

Change compiles clean (`py_compile`). Existing `tests/test_connection_pool.py` assertions (`limit`, `use_dns_cache`, `family`) are unaffected — they don't assert `force_close`/`keepalive_timeout`. The root cause was diagnosed from live coordinator logs plus a network probe of the endpoint; a maintainer should confirm on a live HAOS instance by watching a few poll cycles for the `SocketTimeoutError` retries to stop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling during cloud data updates.
  * Reduced the risk of stalled or delayed readings caused by expired network connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->