### PR TITLE
Fix: entity unavailable every poll cycle since HA core 2026.7 (#29)

### DIFF
--- a/custom_components/tornado/aux_cloud/__init__.py
+++ b/custom_components/tornado/aux_cloud/__init__.py
@@ -123,13 +123,21 @@ class AuxCloudAPI:
         """Get or create shared connector."""
         async with cls._shared_connector_lock:
             if cls._shared_connector is None or cls._shared_connector.closed:
+                # force_close=True: never reuse a pooled connection across
+                # requests. AUX Cloud's own idle-connection timeout is shorter
+                # than the poll interval (~1-4 min), so a kept-alive connection
+                # is always stale by the next poll — reusing it risks an
+                # instantly-failing "poisoned" connection (see #29, made far
+                # more likely by HA core 2026.7's aiohttp 3.13.5->3.14.1 bump).
+                # list_families()/_has_shared_devices() are cached for an
+                # hour, so there's normally only one live request per poll
+                # anyway — keep-alive reuse buys nothing here, just risk.
                 cls._shared_connector = aiohttp.TCPConnector(
                     limit=10,
                     ttl_dns_cache=300,  # Cache DNS results for 5 minutes
                     use_dns_cache=True,
                     family=socket.AF_INET,
-                    keepalive_timeout=120,
-                    force_close=False,
+                    force_close=True,
                 )
                 _LOGGER.info("Created new connector: %s", id(cls._shared_connector))
 
@@ -839,7 +847,16 @@ class AuxCloudAPI:
                 self.list_devices(family["familyid"], shared=True)
                 for family in family_data
             ]
-            await asyncio.gather(*tasks)
+            # return_exceptions=True: one family/group failing must not cancel
+            # its siblings' still-in-flight requests on the shared connector
+            # (see #29 — a cancelled read can leave a broken connection in the
+            # shared keep-alive pool for the next poll to trip over).
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    _LOGGER.warning(
+                        "Error refreshing a family/device group: %s", result
+                    )
         except Exception:
             _LOGGER.exception("Error refreshing data")
             raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,12 @@ aiohttp==3.11.11
 aiohttp-cors==0.7.0
 aiohttp-fast-zlib==0.2.0
 async-lru==2.0.4
+# aiodns==3.2.0 (pinned transitively by homeassistant==2025.1.4) only
+# supports pycares<5's Channel.getaddrinfo() signature; pycares 5.x changed
+# it (and switched to a background-thread shutdown model), breaking
+# test_dns_cache and leaking a thread past test teardown. Unrelated to this
+# PR's fix, but was failing CI on main before this change too.
+pycares<5
 pytest-aiohttp==1.0.5
 pytest-asyncio==0.24.0
 dataclasses-json==0.5.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,13 @@ aiohttp-cors==0.7.0
 aiohttp-fast-zlib==0.2.0
 async-lru==2.0.4
 # aiodns==3.2.0 (pinned transitively by homeassistant==2025.1.4) is
-# incompatible with newer pycares releases in two ways: pycares>=5 changed
-# Channel.getaddrinfo()'s signature (breaks test_dns_cache), and pycares
-# versions between 4.9 and 5.x introduced a background "safe shutdown"
-# thread that leaks past test teardown (breaks test_login_error_handling).
-# 4.8.0 is the newest release confirmed free of both. Unrelated to this
-# PR's fix, but was failing CI on main before this change too.
-pycares==4.8.0
+# incompatible with pycares>=5, which changed Channel.getaddrinfo()'s
+# signature (breaks test_dns_cache). Pin below 5 but require >=4.9 for the
+# CVE-2025-48945 fix (Channel use-after-free) - the resulting background
+# "safe shutdown" thread is handled by tests/conftest.py so it doesn't trip
+# the test suite's lingering-thread check. Unrelated to this PR's fix, but
+# was failing CI on main before this change too.
+pycares>=4.9,<5
 pytest-aiohttp==1.0.5
 pytest-asyncio==0.24.0
 dataclasses-json==0.5.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,14 @@ aiohttp==3.11.11
 aiohttp-cors==0.7.0
 aiohttp-fast-zlib==0.2.0
 async-lru==2.0.4
-# aiodns==3.2.0 (pinned transitively by homeassistant==2025.1.4) only
-# supports pycares<5's Channel.getaddrinfo() signature; pycares 5.x changed
-# it (and switched to a background-thread shutdown model), breaking
-# test_dns_cache and leaking a thread past test teardown. Unrelated to this
+# aiodns==3.2.0 (pinned transitively by homeassistant==2025.1.4) is
+# incompatible with newer pycares releases in two ways: pycares>=5 changed
+# Channel.getaddrinfo()'s signature (breaks test_dns_cache), and pycares
+# versions between 4.9 and 5.x introduced a background "safe shutdown"
+# thread that leaks past test teardown (breaks test_login_error_handling).
+# 4.8.0 is the newest release confirmed free of both. Unrelated to this
 # PR's fix, but was failing CI on main before this change too.
-pycares<5
+pycares==4.8.0
 pytest-aiohttp==1.0.5
 pytest-asyncio==0.24.0
 dataclasses-json==0.5.14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures for the test suite."""
+
+import pycares
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _prewarm_pycares_shutdown_thread() -> None:
+    """
+    Start pycares' background channel-shutdown thread before any test runs.
+
+    pycares >=4.9 (the fix for CVE-2025-48945, a Channel use-after-free) destroys
+    DNS resolver Channels on a lazily-started, process-wide daemon thread
+    ("_run_safe_shutdown_loop"). If that thread first spins up mid-suite (e.g.
+    when a real aiohttp.TCPConnector/aiodns resolver is created in
+    tests/test_connection_pool.py), pytest-homeassistant-custom-component's
+    per-test thread-leak check flags it as a lingering thread and fails an
+    unrelated test. Starting it here, once, before the first per-test
+    before/after thread snapshot is taken, makes it invisible to that diff.
+    """
+    pycares.Channel()

--- a/tests/test_aux_cloud.py
+++ b/tests/test_aux_cloud.py
@@ -31,6 +31,23 @@ TEST_SHARED_DEVICES_CALL_COUNT = 3
 TEST_MIN_DEVICE_COUNT = 2
 
 
+@pytest.fixture(autouse=True)
+def _reset_shared_client_state() -> AsyncGenerator[None, None]:
+    """
+    Reset AuxCloudAPI's class-level shared session/connector between tests.
+
+    Without this, a fake/mocked session or connector left behind by one test
+    (e.g. a bare stub without a `.closed` attribute) leaks into the next test
+    via the shared classvars, since `cleanup_shared_resources` is invoked by
+    the retry path (see #29) and inspects `_shared_session`/`_shared_connector`.
+    """
+    AuxCloudAPI._shared_session = None
+    AuxCloudAPI._shared_connector = None
+    yield
+    AuxCloudAPI._shared_session = None
+    AuxCloudAPI._shared_connector = None
+
+
 @pytest.fixture
 def mock_response() -> MagicMock:
     """Mock aiohttp response."""
@@ -1107,6 +1124,11 @@ async def test_get_shared_connector() -> None:
     assert isinstance(connector1, aiohttp.TCPConnector)
     assert connector1.limit == CONNECTION_POOL_LIMIT
     assert not connector1.closed
+    # Regression test for #29: connections must never be pooled/reused across
+    # requests, since AUX Cloud's own idle-connection timeout is shorter than
+    # the poll interval — a kept-alive connection is always stale by the next
+    # poll and fails instantly when reused (a "poisoned" pooled connection).
+    assert connector1.force_close is True
 
     connector2 = await AuxCloudAPI.get_shared_connector()
     assert connector2 is connector1


### PR DESCRIPTION
## Summary

Fixes #29 — since upgrading to HA core 2026.7 (which bumps `aiohttp` 3.13.5 → 3.14.1), the climate entity flaps `unavailable` on nearly every poll cycle (~360×/day, vs. ~7/day before).

**Root cause:** debug logs show `list_devices()` failing with an instantly-raised `SocketTimeoutError` (~7ms — far too fast to be a real network timeout). That's the signature of a stale/poisoned pooled keep-alive connection being reused after the AUX Cloud server already closed it — made much more likely by aiohttp 3.14.x's changes to cancellation/connection-cleanup handling (confirmed via HA core's `pyproject.toml` diff between `core-2026.6.4` and `core-2026.7.2`).

AUX Cloud's own idle-connection timeout is shorter than our poll interval (~1-4 min), so any connection kept alive in the shared `TCPConnector`'s pool is always stale by the time the next poll tries to reuse it. Keep-alive reuse doesn't actually buy anything here either: `list_families()`/`_has_shared_devices()` are cached for an hour, so there's normally only one live HTTP request per poll.

**Fix:** set `force_close=True` on the shared connector so every request gets a fresh connection instead of risking a poisoned one from the pool. This is simpler and more robust than detecting and selectively invalidating stale connections after the fact (an earlier version of this fix did that — see commit history discussion), and avoids introducing a new failure mode around a shared connection pool being torn down while other requests are in flight.

Also fixed `refresh()`'s unguarded `asyncio.gather()`, which could cancel sibling in-flight `list_devices()` calls sharing the same connector if one family failed — same underlying risk class, on the once-per-startup `refresh()` path rather than every poll.

## Test plan

- [x] `pytest tests/test_aux_cloud.py tests/test_connection_pool.py` — 42 passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] Added regression assertion that the shared connector has `force_close=True`
- [ ] Reporter/community confirmation: unavailable-event count should drop back to the pre-2026.7 baseline (~7/day) after upgrading. Reporter's own SQL query from #29 can be used to verify:

```sql
SELECT date(datetime(s.last_updated_ts,'unixepoch','localtime')) AS day,
       COUNT(*) AS unavailable_events
FROM states s
JOIN states_meta m ON s.metadata_id = m.metadata_id
WHERE m.entity_id = 'climate.YOUR_ENTITY' AND s.state = 'unavailable'
GROUP BY day ORDER BY day;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh robustness so one device group’s failure no longer prevents other groups from refreshing.
  * Updated cloud polling connection handling to avoid reusing pooled connections by forcing connections to close.
* **Tests**
  * Added automatic setup/teardown to reset shared polling client state between tests.
  * Expanded coverage to verify the polling connector is configured to close connections after use.
  * Added a test pre-warm step to prevent unrelated thread-leak failures.
* **Chores**
  * Adjusted `pycares` constraints (with documentation) to avoid incompatibilities while keeping the security fix window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->