### PR TITLE
Expose horizontal swing separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To set up the Tornado Air Conditioner integration in Home Assistant:
 ## Features
 
 - Control power, mode, temperature, and fan speed of your Tornado Aircon units.
+- Control vertical and horizontal swing independently.
 - Monitor current temperature, humidity, and operational status.
 - Automate your air conditioning based on Home Assistant automations.
 

--- a/custom_components/tornado/climate.py
+++ b/custom_components/tornado/climate.py
@@ -13,6 +13,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.climate.const import SWING_OFF, SWING_ON
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     UnitOfTemperature,
@@ -54,7 +55,7 @@ FAN_MODE_MAP = {
 FAN_MODE_MAP_REVERSE = {v: k for k, v in FAN_MODE_MAP.items()}
 
 # Available swing modes
-SWING_MODES = ["off", "vertical", "horizontal", "both"]
+SWING_MODES = [SWING_OFF, SWING_ON]
 
 # Parameter validation
 PARAMETER_VALIDATION = {
@@ -176,6 +177,7 @@ class TornadoClimateEntity(ClimateEntity):
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.FAN_MODE
             | ClimateEntityFeature.SWING_MODE
+            | ClimateEntityFeature.SWING_HORIZONTAL_MODE
             | ClimateEntityFeature.TURN_ON
             | ClimateEntityFeature.TURN_OFF
         )
@@ -186,6 +188,7 @@ class TornadoClimateEntity(ClimateEntity):
         self._attr_fan_modes = list(FAN_MODE_MAP.values())
         self._attr_fan_mode = FAN_MODE_MAP[0]
         self._attr_swing_modes = SWING_MODES
+        self._attr_swing_horizontal_modes = SWING_MODES
         self._attr_min_temp = 16
         self._attr_max_temp = 32
 
@@ -194,6 +197,7 @@ class TornadoClimateEntity(ClimateEntity):
         self._attr_target_temperature = None
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
         self._attr_swing_mode = None
+        self._attr_swing_horizontal_mode = None
         self._attr_hvac_action = HVACAction.OFF
         self._attr_available = False
         # Create entity description
@@ -273,15 +277,11 @@ class TornadoClimateEntity(ClimateEntity):
             )
             self._attr_target_temperature = device_params.get("temp", 0) / 10
             self._attr_current_temperature = device_params.get("envtemp", 0) / 10
-            # Update swing mode based on vertical and horizontal direction
+            # Update vertical and horizontal swing independently
             v_dir = device_params.get("ac_vdir", 0)
             h_dir = device_params.get("ac_hdir", 0)
-            self._attr_swing_mode = {
-                (0, 0): "off",
-                (1, 0): "vertical",
-                (0, 1): "horizontal",
-                (1, 1): "both",
-            }.get((v_dir, h_dir), "off")
+            self._attr_swing_mode = SWING_ON if v_dir else SWING_OFF
+            self._attr_swing_horizontal_mode = SWING_ON if h_dir else SWING_OFF
 
             self._attr_available = True
 
@@ -356,14 +356,22 @@ class TornadoClimateEntity(ClimateEntity):
         )
 
     async def async_set_swing_mode(self, swing_mode: str) -> None:
-        """Set new target swing mode."""
+        """Set vertical swing mode."""
         device_id = self._device.get("endpointId", "Unknown")
-        _LOGGER.info("Setting swing mode to %s for %s", swing_mode, device_id)
-        params = {
-            "ac_vdir": 1 if swing_mode in ["vertical", "both"] else 0,
-            "ac_hdir": 1 if swing_mode in ["horizontal", "both"] else 0,
-        }
-        await self._set_device_params(params)
+        _LOGGER.info("Setting vertical swing mode to %s for %s", swing_mode, device_id)
+        await self._set_device_params({"ac_vdir": 1 if swing_mode == SWING_ON else 0})
+
+    async def async_set_swing_horizontal_mode(self, swing_horizontal_mode: str) -> None:
+        """Set horizontal swing mode."""
+        device_id = self._device.get("endpointId", "Unknown")
+        _LOGGER.info(
+            "Setting horizontal swing mode to %s for %s",
+            swing_horizontal_mode,
+            device_id,
+        )
+        await self._set_device_params(
+            {"ac_hdir": 1 if swing_horizontal_mode == SWING_ON else 0}
+        )
 
     async def async_turn_on(self) -> None:
         """Turn the device on."""

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -9,6 +9,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
+from homeassistant.components.climate.const import SWING_OFF, SWING_ON
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     UnitOfTemperature,
@@ -83,12 +84,15 @@ async def test_climate_entity_initialization(entity: TornadoClimateEntity) -> No
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.FAN_MODE
         | ClimateEntityFeature.SWING_MODE
+        | ClimateEntityFeature.SWING_HORIZONTAL_MODE
         | ClimateEntityFeature.TURN_ON
         | ClimateEntityFeature.TURN_OFF
     )
     assert entity.temperature_unit == UnitOfTemperature.CELSIUS
     assert entity.min_temp == MIN_TEMP
     assert entity.max_temp == MAX_TEMP
+    assert entity.swing_modes == [SWING_OFF, SWING_ON]
+    assert entity.swing_horizontal_modes == [SWING_OFF, SWING_ON]
 
 
 async def test_climate_update(entity: TornadoClimateEntity) -> None:
@@ -100,7 +104,8 @@ async def test_climate_update(entity: TornadoClimateEntity) -> None:
     assert entity.fan_mode == "low"
     assert entity.target_temperature == TARGET_TEMP
     assert entity.current_temperature == CURRENT_TEMP
-    assert entity.swing_mode == "vertical"
+    assert entity.swing_mode == SWING_ON
+    assert entity.swing_horizontal_mode == SWING_OFF
     assert entity.available is True
 
 
@@ -195,28 +200,24 @@ async def test_set_silent_fan_mode(
 async def test_set_swing_mode(
     entity: TornadoClimateEntity, mock_api: MagicMock
 ) -> None:
-    """Test setting swing mode."""
-    # Test vertical mode
-    await entity.async_set_swing_mode("vertical")
-    mock_api.set_device_params.assert_called_once_with(
-        MOCK_DEVICE, {"ac_vdir": 1, "ac_hdir": 0}
-    )
+    """Test setting vertical and horizontal swing modes."""
+    await entity.async_set_swing_mode(SWING_ON)
+    mock_api.set_device_params.assert_called_once_with(MOCK_DEVICE, {"ac_vdir": 1})
 
     mock_api.set_device_params.reset_mock()
 
-    # Test horizontal mode
-    await entity.async_set_swing_mode("horizontal")
-    mock_api.set_device_params.assert_called_once_with(
-        MOCK_DEVICE, {"ac_vdir": 0, "ac_hdir": 1}
-    )
+    await entity.async_set_swing_horizontal_mode(SWING_ON)
+    mock_api.set_device_params.assert_called_once_with(MOCK_DEVICE, {"ac_hdir": 1})
 
     mock_api.set_device_params.reset_mock()
 
-    # Test both mode
-    await entity.async_set_swing_mode("both")
-    mock_api.set_device_params.assert_called_once_with(
-        MOCK_DEVICE, {"ac_vdir": 1, "ac_hdir": 1}
-    )
+    await entity.async_set_swing_mode(SWING_OFF)
+    mock_api.set_device_params.assert_called_once_with(MOCK_DEVICE, {"ac_vdir": 0})
+
+    mock_api.set_device_params.reset_mock()
+
+    await entity.async_set_swing_horizontal_mode(SWING_OFF)
+    mock_api.set_device_params.assert_called_once_with(MOCK_DEVICE, {"ac_hdir": 0})
 
 
 async def test_turn_on(entity: TornadoClimateEntity, mock_api: MagicMock) -> None:


### PR DESCRIPTION
Expose the existing `ac_hdir` property through Home Assistant's climate entity using the supported horizontal swing feature and `on`/`off` modes.

This keeps `ac_vdir` as vertical swing and prevents changing either axis from overwriting the other.

## Testing

- Verified Home Assistant exposes separate horizontal swing controls
- Tested vertical vs. horizontal swing against a live AC
- Ran the focused climate test suite (`19 passed`)
- Ran Ruff formatting and lint checks

<img width="306" height="332" alt="image" src="https://github.com/user-attachments/assets/ca059a49-b4b0-4ca6-acdc-b5e9ee9f8a33" />

Vertical is displayed as just "Swing". This seems to be a Home Assistant card limitation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added independent vertical and horizontal swing controls for Tornado air conditioners.
  - Added separate horizontal swing status and controls.
  - Updated swing options to use standard on/off values.

- **Bug Fixes**
  - Vertical swing commands now affect only vertical airflow direction.
  - Removed combined swing modes that could incorrectly control both directions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->